### PR TITLE
Fix phone app not opening

### DIFF
--- a/Scripts/s4ap/modinfo.py
+++ b/Scripts/s4ap/modinfo.py
@@ -14,7 +14,7 @@ class ModInfo(CommonModInfo):
     @property
     def _version(self) -> str:
         # Mod version
-        return '0.1.10'
+        return '0.1.11b'
 
     @property
     def _author(self) -> str:

--- a/Scripts/s4ap/utils/s4ap_phone_utils.py
+++ b/Scripts/s4ap/utils/s4ap_phone_utils.py
@@ -50,6 +50,8 @@ def _handle_show_max_skills_phone(event_data: S4CLSimTraitAddedEvent):
             elif skill == "Homestyle Cooking":
                 skill_id = f'statistic_Skill_AdultMajor_{skill}'
                 skill = skill.replace("Homestyle ", "")
+            elif skill == "Mixology":
+                skill_id = f'statistic_Skill_AdultMajor_Bartending'
             else:
                 skill_id = f'statistic_Skill_AdultMajor_{skill}'
             skill_id = skill_id.replace(" ", "")


### PR DESCRIPTION
fixed the mixology skill giving an error preventing the phone app from opening.

`ValueError: No names matched 'statistic_skill_adultmajor_mixology'.` no longer occurs.

Internally, the skill is actually named `statistic_Skill_AdultMajor_Bartending` but has a display name of Mixology. This PR fixes the issue. I also incremented the version to 0.1.11b but I can change that to 0.1.12 if needed or 0.1.11.1 (whichever is preferred, though I think 0.1.11b or 0.1.12 are the best options)

Just for the future if you're having issues with some skills, double check the tuning files with sims 4 studio, by searching `statistic/` and scrolling for the `statistic_skill` ones to show up, some other skills are unique (fitness) but you already caught that one.